### PR TITLE
added existsOnSorbet & neo4Jid defaults

### DIFF
--- a/admin/server/api/list/duplicate.js
+++ b/admin/server/api/list/duplicate.js
@@ -22,8 +22,14 @@ function duplicate(listName, query, keystone, user, parent) {
             if (item.isMonetized) {
               item.isMonetized = false;
             }
+            if (item.neo4jId) {
+              item.neo4jId = null;
+            }
+            if (item.existsOnSorbet) {
+              item.existsOnSorbet = false;
+            }
             if (parent) {
-              item[parent.name] = parent.id
+              item[parent.name] = parent.id;
             }
             list.updateItem(duplicated, item, {
               ignoreNoEdit: true,


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)


## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

